### PR TITLE
feat: remove dotenv and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,0 @@
-PORT=8080
-
-# If you want to use a MongoDB database:
-# Uncomment the next line and enter your MongoDB connection settings:
-# MONGO_URL=...

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-.env
 .DS_Store
 smoketest
 temba-prerelease

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -24,13 +24,7 @@ const checkedOut = runCommand(gitCheckoutCommand);
 if (!checkedOut) process.exit(-1);
 
 // Copy necessary file from tmp to project folder
-const filesToCopy = [
-  "src",
-  ".env.example",
-  ".gitignore",
-  "package.template.json",
-  "readme.md",
-];
+const filesToCopy = ["src", ".gitignore", "package.template.json", "readme.md"];
 for (const file of filesToCopy) {
   const copied = runCommand(
     `mv ${projectName}/tmp/${file} ${projectName}/${file}`

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
-        "dotenv": "^16.4.5",
         "temba": "^0.37.0"
       },
       "bin": {
@@ -18,8 +17,7 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@babel/node": "^7.25.0",
-        "@babel/preset-env": "^7.25.4",
-        "@types/dotenv": "^8.2.0"
+        "@babel/preset-env": "^7.25.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1796,16 +1794,6 @@
         "mongodb": "^3.6.8",
         "picoid": "^1.1.2",
         "saslprep": "^1.0.3"
-      }
-    },
-    "node_modules/@types/dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
-      "deprecated": "This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "dotenv": "*"
       }
     },
     "node_modules/accepts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-temba-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-temba-server",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "temba": "^0.37.0"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "@babel/preset-env": "^7.25.4"
   },
   "dependencies": {
-    "temba": "^0.37.0"
+    "temba": "^0.38.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "create-temba-server",
   "version": "1.4.0",
   "description": "Starter project for creating a REST API with Temba",
-  "bin": "./bin/cli.js",
+  "bin": {
+    "create-temba-server": "bin/cli.js"
+  },
   "main": "src/server.js",
   "type": "module",
   "scripts": {
@@ -10,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/bouwe77/temba-starter"
+    "url": "git+https://github.com/bouwe77/temba-starter.git"
   },
   "author": "Bouwe (https://bouwe.io)",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-temba-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Starter project for creating a REST API with Temba",
   "bin": "./bin/cli.js",
   "main": "src/server.js",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,9 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/node": "^7.25.0",
-    "@babel/preset-env": "^7.25.4",
-    "@types/dotenv": "^8.2.0"
+    "@babel/preset-env": "^7.25.4"
   },
   "dependencies": {
-    "dotenv": "^16.4.5",
     "temba": "^0.37.0"
   }
 }

--- a/package.template.json
+++ b/package.template.json
@@ -10,6 +10,6 @@
     "@babel/preset-env": "^7.25.4"
   },
   "dependencies": {
-    "temba": "^0.37.0"
+    "temba": "^0.38.0"
   }
 }

--- a/package.template.json
+++ b/package.template.json
@@ -2,7 +2,7 @@
   "main": "src/server.js",
   "type": "module",
   "scripts": {
-    "start": "node src/server.js"
+    "start": "node --watch src/server.js"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/package.template.json
+++ b/package.template.json
@@ -7,11 +7,9 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/node": "^7.25.0",
-    "@babel/preset-env": "^7.25.4",
-    "@types/dotenv": "^8.2.0"
+    "@babel/preset-env": "^7.25.4"
   },
   "dependencies": {
-    "dotenv": "^16.4.5",
     "temba": "^0.37.0"
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,8 +1,7 @@
-import "dotenv/config";
 import { create } from "temba";
 
 const server = create({
-  port: process.env.PORT || 3000,
+  port: 3000,
 });
 
 server.start();

--- a/test.js
+++ b/test.js
@@ -27,11 +27,6 @@ run(`rm -rf ${folder}`);
 // Call Temba starter script
 run(`node bin/cli.js ${folder}`);
 
-// Create an .env file for the port number
-run(
-  `echo "# This .env is created by the test script and can safely be removed\nPORT=9887" > ${folder}/.env`
-);
-
 // Start the Temba server
 run(`cd ${folder} && npm start`);
 


### PR DESCRIPTION
* Removed dotenv dev dependency: Node can handle environment variables themselves, so no need for dotenv anymore.

* Removed .env.example: Temba users can figure out their own way to define a port for their API, so also no need to provide an .env.example file anymore.

* Added `--watch` to `npm start` command